### PR TITLE
install WordPress to sub-directory

### DIFF
--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -18,7 +18,7 @@ WP_HOSTNAME          = "wordpress.local" # e.g example.com
 WP_IP                = "192.168.33.10" # host ip address
 
 WP_HOME              = "" # path to WP_HOME, e.g blank or /wp or ...
-WP_SITEURL           = "" # path to WP_SITEURL, e.g blank or /wp or ...
+WP_ADDRESS           = "" # path to WordPress directory, e.g blank or sub-directory name like "wp".
 
 WP_TITLE             = "Welcome to the Vagrant" # title
 WP_ADMIN_USER        = "admin" # default user

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -18,7 +18,7 @@ WP_HOSTNAME          = "wordpress.local" # e.g example.com
 WP_IP                = "192.168.33.10" # host ip address
 
 WP_ADDRESS           = "" # path to WordPress directory, e.g blank or sub-directory name like "wp".
-SITE_ADDRESS         = "" # path to sitehome, e.g blank or wp or ...
+SITE_ADDRESS         = "" # path to sitehome, e.g blank or "/wp" or ...
 
 WP_TITLE             = "Welcome to the Vagrant" # title
 WP_ADMIN_USER        = "admin" # default user

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -17,8 +17,8 @@ WP_LANG              = ENV["wp_lang"] || "en_US" # WordPress locale (e.g. ja)
 WP_HOSTNAME          = "wordpress.local" # e.g example.com
 WP_IP                = "192.168.33.10" # host ip address
 
-SITE_ADDRESS         = "" # path to sitehome, e.g blank or wp or ...
 WP_ADDRESS           = "" # path to WordPress directory, e.g blank or sub-directory name like "wp".
+SITE_ADDRESS         = "" # path to sitehome, e.g blank or wp or ...
 
 WP_TITLE             = "Welcome to the Vagrant" # title
 WP_ADMIN_USER        = "admin" # default user

--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -17,7 +17,7 @@ WP_LANG              = ENV["wp_lang"] || "en_US" # WordPress locale (e.g. ja)
 WP_HOSTNAME          = "wordpress.local" # e.g example.com
 WP_IP                = "192.168.33.10" # host ip address
 
-WP_HOME              = "" # path to WP_HOME, e.g blank or /wp or ...
+SITE_ADDRESS         = "" # path to sitehome, e.g blank or wp or ...
 WP_ADDRESS           = "" # path to WordPress directory, e.g blank or sub-directory name like "wp".
 
 WP_TITLE             = "Welcome to the Vagrant" # title


### PR DESCRIPTION
私が確認したところによると、WP_HOMEはスラッシュ有りでOK、無しだとうまくいきませんでした。WP_SITEURLはスラッシュ有りだとNG、無しだとOKでした。

これでうまくいきました。
↓
WP_HOME = "/wp"
WP_SITEURL= "wp"


また、管理画面の表記に合わせて、このように名称を変更してはいかがでしょうか。
WP_ADDRESSが上、SITE_ADDRESSが下にある方がわかりやすいかと思います。

WP_SITEURL => WP_ADDRESS
WP_HOME => SITE_ADDRESS

しかし、私はvagrantfile以外を触る事ができないので、名称を変更したことで当然動かなくなると思います。。。こんなしょうもないプルリクですみません。
より多くの方に使いやすくなるよう、願っています。