### PR TITLE
Correct the variable from SITE_SITEURL to WP_SITEURL

### DIFF
--- a/Vagrantfile.sample
+++ b/Vagrantfile.sample
@@ -18,7 +18,7 @@ WP_HOSTNAME          = "wordpress.local" # e.g example.com
 WP_IP                = "192.168.33.10" # host ip address
 
 WP_HOME              = "" # path to WordPress directory, e.g blank or sub-directory name like "wp".
-SITE_SITEURL         = "" # path to sitehome, e.g blank or "/wp" or ...
+WP_SITEURL           = "" # path to sitehome, e.g blank or "/wp" or ...
 
 WP_TITLE             = "Welcome to the Vagrant" # title
 WP_ADMIN_USER        = "admin" # default user


### PR DESCRIPTION
    vccw/Vagrantfile:128:in `block (2 levels) in <top (required)>': uninitialized constant WP_SITEURL (NameError)

I guess the variable name is bit incorrect.

Thanks.