### PR TITLE
to keep own .gitignore for WordPress

### DIFF
--- a/provision/site-cookbooks/wpcli/recipes/install.rb
+++ b/provision/site-cookbooks/wpcli/recipes/install.rb
@@ -243,7 +243,7 @@ end
 remote_file node[:wpcli][:gitignore] do
   source node[:wpcli][:gitignore_url]
   mode 0644
-  action :create
+  action :create_if_missing
 end
 
 apache_site "000-default" do


### PR DESCRIPTION
vccw 、とても重宝させて頂いています。ありがとうございます。

ところで、
現在、開発用の仮想環境一式を自分用にGit管理しており、各WordPressルート上の.gitignoreファイルも自前で少し手を加えたものを使用しています。

`vagrant provision` 時に当該ファイルが上書きされないようにしてみましたが、いかがでしょうか。