### PR TITLE
change WP_CHEF_COOKBOOKS_PATH example.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -47,7 +47,7 @@ WP_THEME_UNIT_TEST   = false # automatic import theme unit test data
 
 WP_ALWAYS_RESET      = true # always reset database
 
-WP_CHEF_COOKBOOKS_PATH = File.join(File.dirname(__FILE__), 'provision') # path to the cookbooks (e.g. ~/vccw)
+WP_CHEF_COOKBOOKS_PATH = File.join(File.dirname(__FILE__), 'provision') # path to the cookbooks (e.g. File.join('~/vccw', 'provision'))
 
 if WP_LANG === 'ja' then
   WP_THEME_UNIT_TEST_DATA_URI = 'https://raw.githubusercontent.com/jawordpressorg/theme-test-data-ja/master/wordpress-theme-test-date-ja.xml'


### PR DESCRIPTION
vccw を別ディレクトリにおいていた場合、サンプル通りでは cookbook path でエラーが出たため。