### PR TITLE
windowsでファイルパーミッションがおかしくなるのを修正

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -65,7 +65,7 @@ Vagrant.configure(2) do |config|
   config.vm.hostname = WP_HOSTNAME
   config.vm.network :private_network, ip: WP_IP
 
-  config.vm.synced_folder "www/wordpress/", DOCUMENT_ROOT, :create => "true"
+  config.vm.synced_folder "www/wordpress/", DOCUMENT_ROOT, :create => "true", :mount_options => ['dmode=755', 'fmode=644']
 
   if Vagrant.has_plugin?("vagrant-hostsupdater")
     config.hostsupdater.remove_on_suspend = true


### PR DESCRIPTION
windowsでドキュメントルート以下のファイルのパーミッションが777になってしまう問題を修正しました。